### PR TITLE
Lightbox

### DIFF
--- a/Markdown.js
+++ b/Markdown.js
@@ -5,7 +5,13 @@ var {
 var _ = require('lodash');
 var SimpleMarkdown = require('simple-markdown');
 
+const deviceHeight = React.Dimensions.get('window').height
+const deviceWidth = React.Dimensions.get('window').width
+
 var styles = {
+  autolink: {
+    color: 'blue'
+  },
   view: {
   },
   codeBlock: {
@@ -47,6 +53,11 @@ var styles = {
     height: 50, // TODO: React Native needs to support auto image size
     width: 50 // TODO: React Native needs to support auto image size
   },
+  imageBox: {
+    flex: 1,
+    width: deviceWidth,
+    resizeMode: 'contain',
+  },
   inlineCode: {
     backgroundColor: '#eeeeee',
     borderColor: '#dddddd',
@@ -61,6 +72,9 @@ var styles = {
   listItem: {
     flexDirection: 'row'
   },
+  listItemText: {
+    flex: 1,
+  },
   listItemBullet: {
     fontSize: 20,
     lineHeight: 20
@@ -68,11 +82,21 @@ var styles = {
   listItemNumber: {
     fontWeight: 'bold'
   },
+  listRow: {
+    flexDirection: 'row',
+  },
   paragraph: {
     marginTop: 10,
     marginBottom: 10,
     flexWrap: 'wrap',
     flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start'
+  },
+  paragraphWithImage: {
+    flex: 1,
+    marginTop: 10,
+    marginBottom: 10,
     alignItems: 'flex-start',
     justifyContent: 'flex-start'
   },
@@ -109,6 +133,9 @@ var styles = {
   text: {
     color: '#222222'
   },
+  textRow: {
+    flexDirection: 'row',
+  },
   u: {
     borderColor: '#222222',
     borderBottomWidth: 1
@@ -125,8 +152,16 @@ var Markdown = React.createClass({
   },
 
   componentWillMount: function() {
+    if (this.props.enableLightBox && !this.props.navigator) {
+      throw new Error('props.navigator must be specified when enabling lightbox')
+    }
+    var opts = {
+      enableLightBox: this.props.enableLightBox,
+      navigator: this.props.navigator,
+    }
+
     var mergedStyles = _.merge({}, styles, this.props.style);
-    var rules = require('./rules')(mergedStyles);
+    var rules = require('./rules')(mergedStyles, opts);
     rules = _.merge({}, SimpleMarkdown.defaultRules, rules);
 
     var parser = SimpleMarkdown.parserFor(rules);
@@ -135,6 +170,13 @@ var Markdown = React.createClass({
       return parser(blockSource, {inline: false});
     };
     this.renderer = SimpleMarkdown.reactFor(SimpleMarkdown.ruleOutput(rules, 'react'));
+  },
+
+
+  componentDidMount: function() {
+    if (this.props.onLoad) {
+      this.props.onLoad()
+    }
   },
 
   render: function() {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "dependencies": {
     "lodash": "^3.6.0",
+    "react-native-lightbox": "^0.5.0",
     "simple-markdown": "git://github.com/lwansbrough/simple-markdown.git"
   },
   "keywords": [


### PR DESCRIPTION
## Require React Native `0.20+` for Linking Support
- Added [Lightbox](https://github.com/oblador/react-native-lightbox) for image popover, please refer it for the instruction on `navigator` support
  - Lightbox require `navigator` prop for popover
  - `enableLightBox` to toggle for display
- Merged with [react-native-markdown-with-links](https://github.com/britt/react-native-markdown)
- Added `onLoad` to return call once loaded
- Fix Bullet list style
